### PR TITLE
fix getting content from storage

### DIFF
--- a/main/handlers/cleanup.go
+++ b/main/handlers/cleanup.go
@@ -10,7 +10,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
-func HandleMoveHTMLContentToStorage(logger *log.Logger, pgxConn *pgxpool.Pool, supabaseS3EndpointURL string, supabaseAnonKey string) http.HandlerFunc {
+func HandleMoveHTMLContentToStorage(logger *log.Logger, pgxConn *pgxpool.Pool, supabaseURL string, supabaseAnonKey string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		logger.Println("Moving HTML content to storage")
 
@@ -32,7 +32,7 @@ func HandleMoveHTMLContentToStorage(logger *log.Logger, pgxConn *pgxpool.Pool, s
 			}
 
 			// save the html content to the storage
-			err = helpers.SaveFileToStorageFromLocalFile(context.Background(), logger, supabaseS3EndpointURL, "pages", fmt.Sprintf("%d/%d/page.html", urlId, id), htmlContent, supabaseAnonKey)
+			err = helpers.SaveFileToStorageFromLocalFile(context.Background(), logger, supabaseURL, "pages", fmt.Sprintf("%d/%d/page.html", urlId, id), htmlContent, supabaseAnonKey)
 			if err != nil {
 				logger.Println("Error saving HTML content:", err)
 			} else {
@@ -46,7 +46,7 @@ func HandleMoveHTMLContentToStorage(logger *log.Logger, pgxConn *pgxpool.Pool, s
 	}
 }
 
-func HandleMoveMarkdownContentToStorage(logger *log.Logger, pgxConn *pgxpool.Pool, supabaseS3EndpointURL string, supabaseAnonKey string) http.HandlerFunc {
+func HandleMoveMarkdownContentToStorage(logger *log.Logger, pgxConn *pgxpool.Pool, supabaseURL string, supabaseAnonKey string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		logger.Println("Moving HTML content to storage")
 
@@ -68,7 +68,7 @@ func HandleMoveMarkdownContentToStorage(logger *log.Logger, pgxConn *pgxpool.Poo
 			}
 
 			// save the html content to the storage
-			err = helpers.SaveFileToStorageFromLocalFile(context.Background(), logger, supabaseS3EndpointURL, "pages", fmt.Sprintf("%d/%d/page.md", urlId, id), markdownContent, supabaseAnonKey)
+			err = helpers.SaveFileToStorageFromLocalFile(context.Background(), logger, supabaseURL, "pages", fmt.Sprintf("%d/%d/page.md", urlId, id), markdownContent, supabaseAnonKey)
 			if err != nil {
 				logger.Println("Error saving markdown content:", err)
 			} else {

--- a/main/handlers/scrape.go
+++ b/main/handlers/scrape.go
@@ -46,7 +46,7 @@ type URL struct {
 }
 
 // HandleScrapeDocsRaw handles the scraping of documentation from a given URL
-func HandleScrapeDocsRaw(logger *log.Logger, pgxConn *pgxpool.Pool, supabaseS3EndpointURL string, supabaseAnonKey string) http.HandlerFunc {
+func HandleScrapeDocsRaw(logger *log.Logger, pgxConn *pgxpool.Pool, supabaseURL string, supabaseAnonKey string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// Only allow POST requests
 		if r.Method != http.MethodPost {
@@ -266,7 +266,7 @@ func HandleScrapeDocsRaw(logger *log.Logger, pgxConn *pgxpool.Pool, supabaseS3En
 			}
 
 			// Add html to storage
-			err = helpers.SaveFileToStorageFromLocalFile(r.Context(), logger, supabaseS3EndpointURL, "pages", fmt.Sprintf("%d/%d/page.html", urlID, pageID), string(htmlContent), supabaseAnonKey)
+			err = helpers.SaveFileToStorageFromLocalFile(r.Context(), logger, supabaseURL, "pages", fmt.Sprintf("%d/%d/page.html", urlID, pageID), string(htmlContent), supabaseAnonKey)
 			if err != nil {
 				logger.Printf("Failed to save page content to storage for %s: %v", urlStr, err)
 				continue
@@ -303,7 +303,7 @@ func HandleScrapeDocsRaw(logger *log.Logger, pgxConn *pgxpool.Pool, supabaseS3En
 	}
 }
 
-func HandlePagesWithoutMarkdownContent(logger *log.Logger, pgxConn *pgxpool.Pool, supabaseS3EndpointURL string, supabaseAnonKey string) http.HandlerFunc {
+func HandlePagesWithoutMarkdownContent(logger *log.Logger, pgxConn *pgxpool.Pool, supabaseURL string, supabaseAnonKey string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// Only allow POST requests
 		if r.Method != http.MethodPost {
@@ -343,7 +343,7 @@ func HandlePagesWithoutMarkdownContent(logger *log.Logger, pgxConn *pgxpool.Pool
 
 			cleanedMarkdownContent := CleanMarkdown(markdownContent)
 			// Add markdown to storage
-			err = helpers.SaveFileToStorageFromLocalFile(r.Context(), logger, supabaseS3EndpointURL, "pages", fmt.Sprintf("%d/%d/page.md", urlID, pageID), cleanedMarkdownContent, supabaseAnonKey)
+			err = helpers.SaveFileToStorageFromLocalFile(r.Context(), logger, supabaseURL, "pages", fmt.Sprintf("%d/%d/page.md", urlID, pageID), cleanedMarkdownContent, supabaseAnonKey)
 			if err != nil {
 				logger.Printf("Failed to save page content to storage for %d: %v", pageID, err)
 				continue

--- a/main/helpers/supabase.go
+++ b/main/helpers/supabase.go
@@ -42,3 +42,22 @@ func SaveFileToStorageFromLocalFile(ctx context.Context, logger *log.Logger, sup
 	logger.Printf("Successfully uploaded local file %s to Supabase storage bucket %s", fileName, bucketName)
 	return nil
 }
+
+func GetFileContentFromStorage(logger *log.Logger, supabaseURL string, bucketName string, path string) (string, error) {
+	url := fmt.Sprintf("%s/storage/v1/object/public/%s/%s", supabaseURL, bucketName, path)
+	response, err := http.Get(url)
+	if err != nil {
+		logger.Printf("failed to create HTTP request: %v", err)
+		return "", fmt.Errorf("failed to create HTTP request: %v", err)
+	}
+
+	defer response.Body.Close()
+
+	content, err := io.ReadAll(response.Body)
+	if err != nil {
+		logger.Printf("failed to read content: %v", err)
+		return "", fmt.Errorf("failed to read content: %v", err)
+	}
+
+	return string(content), nil
+}

--- a/main/main.go
+++ b/main/main.go
@@ -74,16 +74,16 @@ func run(ctx context.Context, args []string, getenv func(string) string) error {
 		return fmt.Errorf("GEMINI_API_KEY must be set")
 	}
 
-	supabaseS3EndpointURL := getenv("SUPABASE_AWS_ENDPOINT_URL")
-	if supabaseS3EndpointURL == "" {
-		return fmt.Errorf("SUPABASE_AWS_ENDPOINT_URL must be set")
+	supabaseURL := getenv("SUPABASE_URL")
+	if supabaseURL == "" {
+		return fmt.Errorf("SUPABASE_URL must be set")
 	}
 	supabaseAnonKey := getenv("SUPABASE_ANON_KEY")
 	if supabaseAnonKey == "" {
 		return fmt.Errorf("SUPABASE_ANON_KEY must be set")
 	}
 
-	srv := Server(l, pgsqlConnection, ragToolsService.Client, geminiApiKey, supabaseS3EndpointURL, supabaseAnonKey)
+	srv := Server(l, pgsqlConnection, ragToolsService.Client, geminiApiKey, supabaseURL, supabaseAnonKey)
 
 	httpServer := &http.Server{
 		Addr:    net.JoinHostPort("0.0.0.0", "8080"),

--- a/main/routes.go
+++ b/main/routes.go
@@ -28,15 +28,15 @@ func addRoutes(
 	pgxConn *pgxpool.Pool,
 	ragToolsServiceClient pb.MarkdownChunkerServiceClient,
 	geminiApiKey string,
-	supabaseS3EndpointURL string,
+	supabaseURL string,
 	supabaseAnonKey string,
 ) {
-	mux.HandleFunc("/scrape", loggingMiddleware(logger, handlers.HandleScrapeDocsRaw(logger, pgxConn, supabaseS3EndpointURL, supabaseAnonKey)))
-	mux.HandleFunc("/scrape/markdown", loggingMiddleware(logger, handlers.HandlePagesWithoutMarkdownContent(logger, pgxConn, supabaseS3EndpointURL, supabaseAnonKey)))
+	mux.HandleFunc("/scrape", loggingMiddleware(logger, handlers.HandleScrapeDocsRaw(logger, pgxConn, supabaseURL, supabaseAnonKey)))
+	mux.HandleFunc("/scrape/markdown", loggingMiddleware(logger, handlers.HandlePagesWithoutMarkdownContent(logger, pgxConn, supabaseURL, supabaseAnonKey)))
 	mux.HandleFunc("/scrape/markdown/chunk", loggingMiddleware(logger, handlers.HandleChunkingUnProcessedPages(logger, pgxConn, ragToolsServiceClient)))
 	mux.HandleFunc("/embeddings", loggingMiddleware(logger, handlers.HandleSaveEmbeddings(logger, pgxConn, geminiApiKey)))
 	mux.HandleFunc("/retrieval", loggingMiddleware(logger, handlers.HandleRetrievalQuery(logger, pgxConn, geminiApiKey)))
 	mux.HandleFunc("/rag", loggingMiddleware(logger, handlers.HandleRAGQuery(logger, pgxConn, geminiApiKey)))
-	mux.HandleFunc("/docs", loggingMiddleware(logger, handlers.HandleLoadDocsMarkdown(logger, pgxConn, supabaseS3EndpointURL)))
+	mux.HandleFunc("/docs", loggingMiddleware(logger, handlers.HandleLoadDocsMarkdown(logger, pgxConn, supabaseURL)))
 	mux.HandleFunc("/cleanup", loggingMiddleware(logger, handlers.HandleUpdatePageContentFields(logger, pgxConn)))
 }

--- a/main/server.go
+++ b/main/server.go
@@ -13,11 +13,11 @@ func Server(
 	pgxConn *pgxpool.Pool,
 	ragToolsServiceClient pb.MarkdownChunkerServiceClient,
 	geminiApiKey string,
-	supabaseS3EndpointURL string,
+	supabaseURL string,
 	supabaseAnonKey string,
 ) http.Handler {
 	mux := http.NewServeMux()
-	addRoutes(mux, logger, pgxConn, ragToolsServiceClient, geminiApiKey, supabaseS3EndpointURL, supabaseAnonKey)
+	addRoutes(mux, logger, pgxConn, ragToolsServiceClient, geminiApiKey, supabaseURL, supabaseAnonKey)
 
 	var handler http.Handler = mux
 	// add middleware if needed


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced the ability to retrieve file content directly from Supabase storage for documentation pages.

- **Refactor**
  - Updated parameter names from Supabase S3 endpoint URL to a more generic Supabase URL throughout the app.
  - Switched file retrieval for documentation from local file system access to storage API-based access.
  - Improved error logging when file retrieval from storage fails.

- **Chores**
  - Updated environment variable usage from `SUPABASE_AWS_ENDPOINT_URL` to `SUPABASE_URL`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->